### PR TITLE
remove line referencing tox in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,3 @@ exclude CODE_OF_CONDUCT.rst
 exclude CONTRIBUTING.rst
 exclude pre-commit-hook
 exclude requirements.txt
-exclude tox.ini


### PR DESCRIPTION
remove line referencing tox in MANIFEST

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
