### PR TITLE
Fix crashes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,8 @@ build:
   tools:
     python: "3.10"
   jobs:
+    post_create_environment:
+      - pip install poetry
     post_install:
-      - pip install -U poetry
-      - poetry config virtualenvs.create false
-      - poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,4 +17,3 @@ build:
       - pip install poetry
     post_install:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
-

--- a/sphinx_github_changelog/changelog.py
+++ b/sphinx_github_changelog/changelog.py
@@ -41,7 +41,7 @@ def compute_changelog(
     token: Optional[str], options: Dict[str, str]
 ) -> List[nodes.Node]:
     if not token:
-        return no_token(changelog_url=options["changelog-url"])
+        return no_token(changelog_url=options.get("changelog-url"))
 
     owner_repo = extract_github_repo_name(url=options["github"])
     releases = extract_releases(owner_repo=owner_repo, token=token)

--- a/sphinx_github_changelog/changelog.py
+++ b/sphinx_github_changelog/changelog.py
@@ -99,6 +99,10 @@ def extract_pypi_package_name(url: Optional[str]) -> Optional[str]:
 
     return stripped_url[len(prefix) :]  # noqa
 
+def get_release_title(title: Optional[str], tag: str):
+    if not title:
+        return tag
+    return title if tag in title else f"{tag}: {title}"
 
 def node_for_release(
     release: Dict[str, Any], pypi_name: Optional[str] = None
@@ -109,7 +113,7 @@ def node_for_release(
     tag = release["tagName"]
     title = release["name"]
     date = release["publishedAt"][:10]
-    title = title if tag in title else f"{tag}: {title}"
+    title = get_release_title(title=title, tag=tag)
 
     # Section
     id_section = nodes.make_id("release-" + tag)

--- a/sphinx_github_changelog/changelog.py
+++ b/sphinx_github_changelog/changelog.py
@@ -60,7 +60,7 @@ def no_token(changelog_url: Optional[str]) -> List[nodes.Node]:
     par += nodes.Text("Changelog was not built because ")
     par += nodes.literal("", "sphinx_github_changelog_token")
     par += nodes.Text(" parameter is missing in the documentation configuration.")
-    result = [nodes.warning("", par)]
+    result: List[nodes.Node] = [nodes.warning("", par)]
 
     if changelog_url:
         par2 = nodes.paragraph()
@@ -99,10 +99,12 @@ def extract_pypi_package_name(url: Optional[str]) -> Optional[str]:
 
     return stripped_url[len(prefix) :]  # noqa
 
+
 def get_release_title(title: Optional[str], tag: str):
     if not title:
         return tag
     return title if tag in title else f"{tag}: {title}"
+
 
 def node_for_release(
     release: Dict[str, Any], pypi_name: Optional[str] = None

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -155,6 +155,13 @@ def test_node_for_release_title_tag(release_dict):
         changelog.node_for_release(release=release_dict, pypi_name=None)
     )
 
+def test_node_for_release_none_title(release_dict):
+
+    release_dict["name"] = None
+    assert "<title>1.0.0</title>" in node_to_string(
+        changelog.node_for_release(release=release_dict, pypi_name=None)
+    )
+
 
 def test_node_for_release_title_pypy(release_dict):
     value = node_to_string(
@@ -239,3 +246,15 @@ def test_github_call_http_error_connection(requests_mock):
         changelog.github_call(url=url, token="token", query="")
 
     assert str(exc_info.value) == "Could not retrieve changelog from github: bar"
+
+@pytest.mark.parametrize(
+    "title, tag, expected",
+    [
+        ("Foo", "1.0.0", "1.0.0: Foo"),
+        ("1.0.0: Foo", "1.0.0", "1.0.0: Foo"),
+        ("Fix 1.0.0", "1.0.1", "1.0.1: Fix 1.0.0"),
+        (None, "1.0.0", "1.0.0"),
+    ],
+)
+def test_get_release_title(title, tag, expected):
+    assert changelog.get_release_title(title=title, tag=tag) == expected

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -15,14 +15,6 @@ def extract_releases(mocker, release_dict):
     )
 
 
-@pytest.fixture
-def options():
-    def _(kwargs):
-        return {"changelog-url": None, "github": None, "pypi": None, **kwargs}
-
-    return _
-
-
 def node_to_string(node):
     if isinstance(node, list):
         return canonicalize(
@@ -49,16 +41,16 @@ def canonicalize(value):
     )
 
 
-def test_compute_changelog_no_token(options):
-    nodes = changelog.compute_changelog(token=None, options=options({}))
+def test_compute_changelog_no_token():
+    nodes = changelog.compute_changelog(token=None, options={})
     assert len(nodes) == 1
 
     assert "Changelog was not built" in node_to_string(nodes[0])
 
 
-def test_compute_changelog_token(options, extract_releases):
+def test_compute_changelog_token(extract_releases):
     nodes = changelog.compute_changelog(
-        token="token", options=options({"github": "https://github.com/a/b/releases"})
+        token="token", options={"github": "https://github.com/a/b/releases"}
     )
     assert "1.0.0: A new hope" in node_to_string(nodes[0])
 

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -147,8 +147,8 @@ def test_node_for_release_title_tag(release_dict):
         changelog.node_for_release(release=release_dict, pypi_name=None)
     )
 
-def test_node_for_release_none_title(release_dict):
 
+def test_node_for_release_none_title(release_dict):
     release_dict["name"] = None
     assert "<title>1.0.0</title>" in node_to_string(
         changelog.node_for_release(release=release_dict, pypi_name=None)
@@ -238,6 +238,7 @@ def test_github_call_http_error_connection(requests_mock):
         changelog.github_call(url=url, token="token", query="")
 
     assert str(exc_info.value) == "Could not retrieve changelog from github: bar"
+
 
 @pytest.mark.parametrize(
     "title, tag, expected",


### PR DESCRIPTION
Closes #123 

Fix 2 crashes:
- Crash if there's no token and no provided changelog url
- Crash if a release has no title (because GitHub sends `None` instead of an empty string :( )

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
