### PR TITLE
Fix expiring image URLs in release descriptions

### DIFF
--- a/sphinx_github_changelog/changelog.py
+++ b/sphinx_github_changelog/changelog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from typing import Any
 
@@ -161,6 +162,21 @@ def get_release_title(title: str | None, tag: str):
     return title if tag in title else f"{tag}: {title}"
 
 
+def transform_private_image_urls(html: str) -> str:
+    """Convert signed private image URLs to permanent user-attachments URLs.
+
+    When GitHub's GraphQL API returns release descriptions, images uploaded via
+    drag-and-drop are returned as signed private-user-images.githubusercontent.com
+    URLs with 5-minute JWT expiration. This converts them to permanent
+    github.com/user-attachments/assets/ URLs.
+    """
+    pattern = (
+        r"https://private-user-images\.githubusercontent\.com/"
+        r"\d+/(\d+)-([a-f0-9-]{36})\.([a-z]+)\?[^\"'>\s]+"
+    )
+    return re.sub(pattern, r"https://github.com/user-attachments/assets/\2", html)
+
+
 def node_for_release(
     release: dict[str, Any], pypi_name: str | None = None
 ) -> nodes.Node | None:
@@ -193,7 +209,8 @@ def node_for_release(
     section += subtitle_paragraph
 
     # Body
-    section += nodes.raw(text=release["descriptionHTML"], format="html")
+    html_content = transform_private_image_urls(release["descriptionHTML"])
+    section += nodes.raw(text=html_content, format="html")
     return section
 
 

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -319,3 +319,53 @@ def test_get_token_from_env(monkeypatch):
     assert credentials.get_token_from_env() == "testtoken"
     monkeypatch.delenv("SPHINX_GITHUB_CHANGELOG_TOKEN", raising=False)
     assert credentials.get_token_from_env() is None
+
+
+class TestTransformPrivateImageUrls:
+    """Tests for transform_private_image_urls function."""
+
+    def test_transforms_private_image_url(self):
+        html = (
+            '<img src="https://private-user-images.githubusercontent.com/'
+            "123/456789-abcd1234-5678-90ab-cdef-123456789012.png"
+            '?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9&amp;exp=1234567890">'
+        )
+        result = changelog.transform_private_image_urls(html)
+        assert result == (
+            '<img src="https://github.com/user-attachments/assets/'
+            'abcd1234-5678-90ab-cdef-123456789012">'
+        )
+
+    def test_transforms_multiple_urls(self):
+        html = (
+            '<img src="https://private-user-images.githubusercontent.com/'
+            '123/111-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.png?jwt=token1">'
+            '<img src="https://private-user-images.githubusercontent.com/'
+            '456/222-11111111-2222-3333-4444-555555555555.jpg?jwt=token2">'
+        )
+        result = changelog.transform_private_image_urls(html)
+        assert (
+            "https://github.com/user-attachments/assets/"
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        ) in result
+        assert (
+            "https://github.com/user-attachments/assets/"
+            "11111111-2222-3333-4444-555555555555"
+        ) in result
+        assert "private-user-images" not in result
+
+    def test_preserves_other_urls(self):
+        html = (
+            '<img src="https://example.com/image.png">'
+            '<a href="https://github.com/repo">link</a>'
+        )
+        result = changelog.transform_private_image_urls(html)
+        assert result == html
+
+    def test_handles_empty_string(self):
+        assert changelog.transform_private_image_urls("") == ""
+
+    def test_handles_html_without_images(self):
+        html = "<p>No images here</p>"
+        result = changelog.transform_private_image_urls(html)
+        assert result == html


### PR DESCRIPTION
(Possibly) Closes #120 

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
- [x] Documentation
  - [x] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->

When fetching release content via GitHub's GraphQL API, images uploaded via **drag-and-drop** (`github.com/user-attachments/assets/`) are returned as signed `private-user-images.githubusercontent.com` URLs with 5-minute JWT expiration. This causes images in generated changelogs to break shortly after the documentation is built.

Added `transform_private_image_urls()` function that uses regex to convert:

`https://private-user-images.githubusercontent.com/123/456-abcd1234-5678-90ab-cdef-123456789012.png?jwt=...`

to

`https://github.com/user-attachments/assets/abcd1234-5678-90ab-cdef-123456789012
`