### PR TITLE
Remove convert_alerts option — MyST handles alert conversion

### DIFF
--- a/sphinx_github_changelog/__init__.py
+++ b/sphinx_github_changelog/__init__.py
@@ -29,13 +29,6 @@ def setup(app):
         default=os.environ.get(graphql_url_name.upper()),
         rebuild="html",
     )
-    app.add_config_value(
-        name="sphinx_github_changelog_convert_alerts",
-        default=True,
-        rebuild="html",
-        types=[bool],
-    )
-
     app.add_directive("changelog", changelog.ChangelogDirective)
 
     return {

--- a/sphinx_github_changelog/changelog.py
+++ b/sphinx_github_changelog/changelog.py
@@ -44,7 +44,6 @@ class ChangelogDirective(Directive):
                 options=self.options,
                 root_url=config.sphinx_github_changelog_root_repo,
                 graphql_url=config.sphinx_github_changelog_graphql_url,
-                convert_alerts=config.sphinx_github_changelog_convert_alerts,
             )
         except ChangelogError as exc:
             raise self.error(str(exc))
@@ -55,7 +54,6 @@ def compute_changelog(
     options: dict[str, str],
     root_url: str | None = None,
     graphql_url: str | None = None,
-    convert_alerts: bool = True,
 ) -> list[nodes.Node]:
     if options.get("github"):
         # If a github URL is explicitly provided, validate that it is in
@@ -96,10 +94,7 @@ def compute_changelog(
     pypi_name = extract_pypi_package_name(url=options.get("pypi"))
 
     result_nodes = (
-        node_for_release(
-            release=release, pypi_name=pypi_name, convert_alerts=convert_alerts
-        )
-        for release in releases
+        node_for_release(release=release, pypi_name=pypi_name) for release in releases
     )
 
     return [n for n in result_nodes if n is not None]
@@ -188,7 +183,6 @@ def transform_private_image_urls(html: str) -> str:
 def node_for_release(
     release: dict[str, Any],
     pypi_name: str | None = None,
-    convert_alerts: bool = True,
 ) -> nodes.Node | None:
     if release["isDraft"]:
         return None  # For now, draft releases are excluded
@@ -288,7 +282,7 @@ def convert_markdown_to_nodes(markdown: str) -> list[nodes.Node]:
     if not markdown or not markdown.strip():
         return []
     parser = Parser()
-    settings = get_default_settings(Parser)
+    settings = get_default_settings(parser)
 
     settings.myst_gfm_only = True
 

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -388,31 +388,6 @@ def test_converts_alerts_by_default(release_dict):
     assert "<title>Note</title>" in result_str
 
 
-def test_converts_alerts_when_enabled(release_dict):
-    release_dict["description"] = ALERT_MARKDOWN
-    result = changelog.node_for_release(
-        release=release_dict, pypi_name=None, convert_alerts=True
-    )
-    result_str = node_to_string(result)
-    assert '<admonition classes="note">' in result_str
-
-
-def test_preserves_raw_html_when_disabled(release_dict):
-    release_dict["description"] = ALERT_MARKDOWN
-    result = changelog.node_for_release(
-        release=release_dict, pypi_name=None, convert_alerts=False
-    )
-    # Check that the result contains a raw node with the alert HTML
-    from docutils import nodes
-
-    raw_nodes = [n for n in result.children if isinstance(n, nodes.raw)]
-    assert len(raw_nodes) == 1  # Single raw node containing all HTML
-    raw_content = str(raw_nodes[0])
-    # When convert_alerts=False, alerts are still rendered to HTML
-    # by markdown-it but not converted to admonitions
-    assert "markdown-alert" in raw_content
-
-
 def test_preserves_non_alert_content(release_dict):
     release_dict["description"] = ALERT_MARKDOWN
     result = changelog.node_for_release(release=release_dict, pypi_name=None)


### PR DESCRIPTION
Removed the convert_alerts option from #189 since MyST handles it unconditionally. The remaining failing tests should resolve with MyST's new release