### PR TITLE
chore: clean up pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,10 +141,18 @@ Authentication
 The extension uses the GitHub GraphQL API to retrieve the changelog. This
 requires authentication using a GitHub API token.
 
-However if you use git over HTTPS, or the ``gh`` CLI, you probably already have a
-suitable token, which ``sphinx-github-changelog`` will automatically use.
+Tokens can be read from (in this order):
 
-In CI like GitHub Actions you can pass a token explicitly as an environment
+- ``sphinx_github_changelog_token`` in ``conf.py`` (please do **NOT** commit your secrets)
+- ``SPHINX_GITHUB_CHANGELOG_TOKEN`` environment variable
+- ``GITHUB_TOKEN`` environment variable
+- Your ``git`` configuration, using `git's credential system`_
+- The ``gh`` command, using `the auth token command`_
+
+.. _`git's credential system`: https://git-scm.com/docs/git-credential
+.. _`the auth token command`: https://cli.github.com/manual/gh_auth_token
+
+When using GitHub Actions, you can pass a token explicitly as an environment
 variable:
 
 .. code-block:: yaml
@@ -154,24 +162,28 @@ variable:
       env:
         SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ github.token }}
 
-In remaining cases you may need to create a personal access token. If the
-repository is public, the token doesn't need any special access (you can
-uncheck eveything). For private and internal repositories, the token must
-have ``repo`` scope (classic tokens) or ``contents: read`` access (fine-grained
-tokens).
+If you're not in one of the cases above (e.g. for ReadTheDocs, at least for the `time
+being`__), you'll need a personal access token. If the repository is public, the token
+doesn't need any special access (you can uncheck everything). For private and internal
+repositories, the token must have ``repo`` scope (classic tokens) or ``contents: read``
+access (fine-grained tokens).
 
-Pass the token as the ``SPHINX_GITHUB_CHANGELOG_TOKEN`` environment variable.
-You can also set the token as ``sphinx_github_changelog_token`` in ``conf.py``,
-but you should never commit secrets such as this.
+.. __: https://github.com/readthedocs/readthedocs.org/issues/13053
+
+Pass the token as the ``SPHINX_GITHUB_CHANGELOG_TOKEN`` (or ``GITHUB_TOKEN``)
+environment variable. You can also set the token as ``sphinx_github_changelog_token`` in
+``conf.py``, but you should never commit secrets such as this.
 
 
 Extension options (``conf.py``)
 -------------------------------
 
-- ``sphinx_github_changelog_token``: GitHub API token, if needed.
+- ``sphinx_github_changelog_token`` (optional): GitHub API token, if needed, see above
+  (please do **NOT** commit your secrets).
 
-Two options are accepted for backwards compatibility, but are likely detected
-automatically from the ``:github:`` parameter to the directive:
+The following options are useful in some cases, though most of the time, the
+corresponding values will be detected automatically from the ``:github:`` parameter
+passed to the directive:
 
 - ``sphinx_github_changelog_root_repo`` (optional): Root URL to the repository.
 - ``sphinx_github_changelog_graphql_url`` (optional): URL to GraphQL API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "sphinx-github-changelog"
 dynamic = ["version"]
 description = "Build a sphinx changelog from GitHub Releases"
 authors = [{ name = "Joachim Jablon", email = "ewjoachim@gmail.com" }]
-requires-python = ">=3.11"
+requires-python = ">= 3.11"
 readme = "README.rst"
 license = "MIT"
 license-files = ["LICENSE"]
@@ -61,7 +61,6 @@ exclude = ["tests", ".venv", "scripts", ".github"]
 typeCheckingMode = "standard"
 
 [tool.ruff]
-target-version = "py39"
 extend-exclude = [".venv"]
 
 [tool.ruff.lint]

--- a/sphinx_github_changelog/__init__.py
+++ b/sphinx_github_changelog/__init__.py
@@ -1,39 +1,5 @@
 from __future__ import annotations
 
-import importlib.metadata
-import os
+from .setup import setup
 
-from sphinx_github_changelog import changelog
-
-__all__: list = []
-
-
-def version() -> str:
-    return importlib.metadata.version("sphinx-github-changelog")
-
-
-def setup(app):
-    token_name = "sphinx_github_changelog_token"
-    app.add_config_value(
-        name=token_name, default=os.environ.get(token_name.upper()), rebuild="html"
-    )
-    root_repo_name = "sphinx_github_changelog_root_repo"
-    app.add_config_value(
-        name=root_repo_name,
-        default=os.environ.get(root_repo_name.upper()),
-        rebuild="html",
-    )
-    graphql_url_name = "sphinx_github_changelog_graphql_url"
-    app.add_config_value(
-        name=graphql_url_name,
-        default=os.environ.get(graphql_url_name.upper()),
-        rebuild="html",
-    )
-
-    app.add_directive("changelog", changelog.ChangelogDirective)
-
-    return {
-        "version": version(),
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
+__all__: list = ["setup"]

--- a/sphinx_github_changelog/changelog.py
+++ b/sphinx_github_changelog/changelog.py
@@ -1,25 +1,13 @@
 from __future__ import annotations
 
-import re
-from collections.abc import Iterable
-from typing import Any
-
-import httpx
 from docutils import nodes
 from docutils.frontend import get_default_settings
-
-# types-docutils (from typeshed) is usable but incomplete.
-# docutils-stubs is more complete but
-# https://github.com/tk0miya/docutils-stubs/issues/33
 from docutils.parsers.rst import Directive, directives
 from docutils.utils import new_document
 from myst_parser.parsers.docutils_ import Parser
 
-from . import credentials, urls
-
-
-class ChangelogError(Exception):
-    pass
+from . import config as config_module
+from . import credentials, exceptions, github_releases, urls
 
 
 class ChangelogDirective(Directive):
@@ -37,61 +25,44 @@ class ChangelogDirective(Directive):
     add_index = False
 
     def run(self) -> list[nodes.Node]:
-        config = self.state.document.settings.env.config
+        options = config_module.ChangelogDirectiveOptions.from_options(self.options)
+        config = config_module.ChangelogConfig.from_sphinx_env_config(
+            self.state.document.settings.env.config
+        )
         try:
-            return compute_changelog(
-                token=config.sphinx_github_changelog_token,
-                options=self.options,
-                root_url=config.sphinx_github_changelog_root_repo,
-                graphql_url=config.sphinx_github_changelog_graphql_url,
-            )
-        except ChangelogError as exc:
+            return compute_changelog(options=options, config=config)
+        except exceptions.ChangelogError as exc:
             raise self.error(str(exc))
 
 
 def compute_changelog(
-    token: str | None,
-    options: dict[str, str],
-    root_url: str | None = None,
-    graphql_url: str | None = None,
+    options: config_module.ChangelogDirectiveOptions,
+    config: config_module.ChangelogConfig,
 ) -> list[nodes.Node]:
-    if options.get("github"):
-        # If a github URL is explicitly provided, validate that it is in
-        # the correct format i.e. refers to the /releases page.
-        github_url = options["github"]
-        root_url = root_url or urls.get_root_url(github_url)
-        owner_repo = extract_github_repo_name(github_url, root_url)
-    else:
-        # If no github URL is provided, try to get it from the git remote
-        # and validate that it is in the correct format.
-        remote_url = urls.get_default_github_url()
-        parsed_repo = remote_url and urls.parse_github_repo_from_url(remote_url)
-        if not parsed_repo:
-            raise ChangelogError(
-                "No :github: release URL provided and unable to determine it from "
-                "git remotes. Please provide a GitHub release URL in the format "
-                "(https://github.com/:owner/:repo/releases)"
-            )
-        owner_repo = parsed_repo
-        github_url = f"{remote_url}/releases"
-
-    # If graphql_url is not provided, derive from github_url
-    if not graphql_url:
-        graphql_url = urls.get_github_graphql_url(github_url)
+    try:
+        github_params = urls.extract_github_params(options=options, config=config)
+    except exceptions.CouldNotExtract as exc:
+        raise exceptions.ChangelogError(
+            "No :github: release URL provided and unable to determine it from "
+            "git remotes. Please provide a GitHub release URL in the format "
+            "(https://github.com/:owner/:repo/releases)"
+        ) from exc
 
     # If token is not provided, try to get it from helpers
+    token = config.token
     if not token:
-        host = urls.get_github_host_from_url(github_url)
-        token = credentials.get_github_token(host)
+        try:
+            token = credentials.get_github_token(host=github_params.hostname)
+        except exceptions.CouldNotExtract:
+            return no_token(changelog_url=options.changelog_url)
 
-    if not token:
-        return no_token(changelog_url=options.get("changelog-url"))
-
-    releases = extract_releases(
-        owner_repo=owner_repo, token=token, graphql_url=graphql_url
+    releases = github_releases.extract_releases(
+        github_params=github_params,
+        token=token,
+        graphql_url=config.graphql_url,
     )
 
-    pypi_name = extract_pypi_package_name(url=options.get("pypi"))
+    pypi_name = extract_pypi_package_name(url=options.pypi)
 
     result_nodes = (
         node_for_release(release=release, pypi_name=pypi_name) for release in releases
@@ -126,24 +97,6 @@ def no_token(changelog_url: str | None) -> list[nodes.Node]:
     return result
 
 
-def extract_github_repo_name(url: str, root_url: str | None = None) -> str:
-    stripped_url = url.rstrip("/")
-    prefix, postfix = (
-        root_url if root_url is not None else "https://github.com/",
-        "/releases",
-    )
-    if not prefix.endswith("/"):
-        prefix += "/"
-    url_is_correct = stripped_url.startswith(prefix) and stripped_url.endswith(postfix)
-    if not url_is_correct:
-        raise ChangelogError(
-            "Changelog needs a Github releases URL "
-            f"({prefix}:owner/:repo/releases). Received {url}"
-        )
-
-    return stripped_url[len(prefix) : -len(postfix)]
-
-
 def extract_pypi_package_name(url: str | None) -> str | None:
     if not url:
         return None
@@ -151,7 +104,7 @@ def extract_pypi_package_name(url: str | None) -> str | None:
     prefix = "https://pypi.org/project/"
     url_is_correct = stripped_url.startswith(prefix)
     if not url_is_correct:
-        raise ChangelogError(
+        raise exceptions.ChangelogError(
             "Changelog needs a PyPI project URL "
             f"(https://pypi.org/project/:project). Received {url}"
         )
@@ -165,31 +118,16 @@ def get_release_title(title: str | None, tag: str):
     return title if tag in title else f"{tag}: {title}"
 
 
-def transform_private_image_urls(html: str) -> str:
-    """Convert signed private image URLs to permanent user-attachments URLs.
-
-    When GitHub's GraphQL API returns release descriptions, images uploaded via
-    drag-and-drop are returned as signed private-user-images.githubusercontent.com
-    URLs with 5-minute JWT expiration. This converts them to permanent
-    github.com/user-attachments/assets/ URLs.
-    """
-    pattern = (
-        r"https://private-user-images\.githubusercontent\.com/"
-        r"\d+/(\d+)-([a-f0-9-]{36})\.([a-z]+)\?[^\"'>\s]+"
-    )
-    return re.sub(pattern, r"https://github.com/user-attachments/assets/\2", html)
-
-
 def node_for_release(
-    release: dict[str, Any],
+    release: github_releases.Release,
     pypi_name: str | None = None,
 ) -> nodes.Node | None:
-    if release["isDraft"]:
+    if release.is_draft:
         return None  # For now, draft releases are excluded
 
-    tag = release["tagName"]
-    title = release["name"]
-    date = release["publishedAt"][:10]
+    tag = release.tag_name
+    title = release.name
+    date = release.published_at.isoformat()
     title = get_release_title(title=title, tag=tag)
 
     # Section
@@ -202,7 +140,7 @@ def node_for_release(
     subtitle += nodes.Text(f"Released on {date} - ")
 
     # Links
-    subtitle += nodes.reference("", "GitHub", refuri=release["url"])
+    subtitle += nodes.reference("", "GitHub", refuri=release.url)
     if pypi_name:
         subtitle += nodes.Text(" - ")
         url = f"https://pypi.org/project/{pypi_name}/{tag}/"
@@ -212,70 +150,11 @@ def node_for_release(
     subtitle_paragraph += subtitle
     section += subtitle_paragraph
 
-    # Body - parse raw markdown with markdown-it-py
-    markdown_content = transform_private_image_urls(release["description"] or "")
-
-    changelog_nodes = convert_markdown_to_nodes(markdown_content)
-    section += changelog_nodes
+    section += convert_markdown_to_nodes(release.description)
     return section
 
 
-def extract_releases(
-    owner_repo: str, token: str, graphql_url: str | None = None
-) -> Iterable[dict[str, Any]]:
-    # Necessary for GraphQL
-    owner, repo = owner_repo.split("/")
-    query = f"""
-    query {{
-        repository(owner: "{owner}", name: "{repo}") {{
-            releases(orderBy: {{field: CREATED_AT, direction: DESC}}, first:100) {{
-                nodes {{
-                    name, description, url, tagName, publishedAt, isDraft
-                }}
-            }}
-        }}
-    }}
-    """
-    full_query = {"query": query.replace("\n", "")}
-
-    url = "https://api.github.com/graphql" if graphql_url is None else graphql_url
-
-    result = github_call(url=url, query=full_query, token=token)
-    if "errors" in result:
-        raise ChangelogError(
-            "GitHub API error response: \n"
-            + "\n".join(e.get("message", str(e)) for e in result["errors"])
-        )
-    try:
-        releases = result["data"]["repository"]["releases"]["nodes"]
-        # If you don't have the right to see draft releases, they're "None"
-        return [r for r in releases if r]
-    except (KeyError, TypeError):
-        raise ChangelogError(f"GitHub API error unexpected format:\n{result!r}")
-
-
-def github_call(url, token, query):
-    try:
-        response = httpx.post(
-            url, json=query, headers={"Authorization": f"token {token}"}
-        ).raise_for_status()
-
-    except httpx.HTTPStatusError as exc:
-        # GraphQL always responds 200
-        raise ChangelogError(
-            f"Unexpected GitHub API error status code: {exc.response.status_code}\n"
-            f"{exc.response.text}"
-        ) from exc
-    except httpx.HTTPError as exc:
-        raise ChangelogError(
-            "Could not retrieve changelog from github: " + str(exc)
-        ) from exc
-
-    # Let's not imagine if GitHub responds non-json...
-    return response.json()
-
-
-def convert_markdown_to_nodes(markdown: str) -> list[nodes.Node]:
+def convert_markdown_to_nodes(markdown: str | None) -> list[nodes.Node]:
     """
     Convert markdown to docutils nodes
     """

--- a/sphinx_github_changelog/config.py
+++ b/sphinx_github_changelog/config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, ClassVar
+
+
+@dataclasses.dataclass
+class ChangelogDirectiveOptions:
+    changelog_url: str | None = None
+    github: str | None = None
+    pypi: str | None = None
+
+    @classmethod
+    def from_options(cls, options: dict[str, str]):
+        return cls(
+            changelog_url=options.get("changelog-url"),
+            github=options.get("github"),
+            pypi=options.get("pypi"),
+        )
+
+
+@dataclasses.dataclass
+class ChangelogConfig:
+    token: str | None = None
+    root_repo: str | None = None
+    graphql_url: str | None = None
+
+    prefix: ClassVar[str] = "sphinx_github_changelog"
+
+    @classmethod
+    def get_field_names(cls) -> list[str]:
+        return [f.name for f in dataclasses.fields(cls)]
+
+    @classmethod
+    def from_sphinx_env_config(cls, sphinx_config: Any):
+        return cls(
+            token=sphinx_config.sphinx_github_changelog_token,
+            root_repo=sphinx_config.sphinx_github_changelog_root_repo,
+            graphql_url=sphinx_config.sphinx_github_changelog_graphql_url,
+        )

--- a/sphinx_github_changelog/credentials.py
+++ b/sphinx_github_changelog/credentials.py
@@ -11,13 +11,18 @@ import os
 import subprocess
 from contextlib import suppress
 
+from . import exceptions
 
-def get_token_from_env(host: str = "github.com") -> str | None:
+
+def get_token_from_env() -> str | None:
     """Get a GitHub token from the SPHINX_GITHUB_CHANGELOG_TOKEN env var.
 
     Return None if the environment variable is not set.
     """
-    return os.environ.get("SPHINX_GITHUB_CHANGELOG_TOKEN")
+    if "SPHINX_GITHUB_CHANGELOG_TOKEN" in os.environ:
+        return os.environ["SPHINX_GITHUB_CHANGELOG_TOKEN"]
+
+    return os.environ.get("GITHUB_TOKEN")
 
 
 def is_github_token(token: str) -> bool:
@@ -33,7 +38,7 @@ def is_github_token(token: str) -> bool:
     return token.startswith("gh") and len(token) > 4 and token[3] == "_"
 
 
-def get_token_from_git_credential(host: str = "github.com") -> str | None:
+def get_token_from_git_credential(host: str) -> str | None:
     """
     Get a GitHub access token using git's credential helper.
 
@@ -47,14 +52,14 @@ def get_token_from_git_credential(host: str = "github.com") -> str | None:
             input=f"protocol=https\nhost={host}\n",
             text=True,
         )
-        for ln in resp.splitlines():
-            key, _, value = ln.partition("=")
+        for line in resp.splitlines():
+            key, value = line.split("=", maxsplit=1)
             if key == "password" and is_github_token(value):
                 return value
     return None
 
 
-def get_token_from_gh_cli(host: str = "github.com") -> str | None:
+def get_token_from_gh_cli(host: str) -> str | None:
     """Get a GitHub token using the GitHub CLI (gh auth token)."""
     with suppress(subprocess.CalledProcessError, FileNotFoundError):
         token = subprocess.check_output(
@@ -65,7 +70,7 @@ def get_token_from_gh_cli(host: str = "github.com") -> str | None:
     return None
 
 
-def get_github_token(host: str = "github.com") -> str | None:
+def get_github_token(host: str) -> str:
     """
     Try to obtain a GitHub token using several mechanisms in order.
 
@@ -73,10 +78,13 @@ def get_github_token(host: str = "github.com") -> str | None:
     2. git credential helper
     3. gh CLI
 
-    Returns None if no token is found.
+    Raises CouldNotExtract if no token is found.
     """
-    return (
-        get_token_from_env(host)
-        or get_token_from_git_credential(host)
-        or get_token_from_gh_cli(host)
+    token = (
+        get_token_from_env()
+        or get_token_from_git_credential(host=host)
+        or get_token_from_gh_cli(host=host)
     )
+    if not token:
+        raise exceptions.CouldNotExtract("No GitHub token found")
+    return token

--- a/sphinx_github_changelog/exceptions.py
+++ b/sphinx_github_changelog/exceptions.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class ChangelogError(Exception):
+    pass
+
+
+class CouldNotExtract(ChangelogError):
+    pass
+
+
+class GitHubAPIError(ChangelogError):
+    pass

--- a/sphinx_github_changelog/github_releases.py
+++ b/sphinx_github_changelog/github_releases.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from collections.abc import Sequence
+
+import httpx
+
+from . import exceptions, urls
+
+
+@dataclasses.dataclass
+class Release:
+    name: str | None
+    description: str | None
+    url: str
+    tag_name: str
+    published_at: datetime.date
+    is_draft: bool
+
+    @classmethod
+    def from_graphql(cls, data: dict) -> Release:
+        return cls(
+            name=data["name"],
+            description=data["description"],
+            url=data["url"],
+            tag_name=data["tagName"],
+            published_at=datetime.date.fromisoformat(data["publishedAt"][:10]),
+            is_draft=data["isDraft"],
+        )
+
+
+def extract_releases(
+    github_params: urls.GitHubParams,
+    token: str,
+    graphql_url: str | None = None,
+) -> Sequence[Release]:
+    query = """
+    query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+            releases(orderBy: {field: CREATED_AT, direction: DESC}, first:100) {
+                nodes {
+                    name, description, url, tagName, publishedAt, isDraft
+                }
+            }
+        }
+    }
+    """
+    payload = {
+        "query": query,
+        "variables": {"owner": github_params.owner, "repo": github_params.repo},
+    }
+    url = graphql_url or github_params.graphql_url
+    result = github_call(url=url, payload=payload, token=token)
+    try:
+        releases = result["data"]["repository"]["releases"]["nodes"]
+        # If you don't have the right to see draft releases, they're "None"
+        return [Release.from_graphql(r) for r in releases if r]
+    except (KeyError, TypeError):
+        raise exceptions.GitHubAPIError(
+            f"GitHub API error unexpected format:\n{result!r}"
+        )
+
+
+def github_call(url: str, token: str, payload: dict) -> dict:
+    try:
+        response = httpx.post(
+            url, json=payload, headers={"Authorization": f"token {token}"}
+        ).raise_for_status()
+
+    except httpx.HTTPStatusError as exc:
+        # GraphQL always responds 200
+        raise exceptions.GitHubAPIError(
+            f"Unexpected GitHub API error status code: {exc.response.status_code}\n"
+            f"{exc.response.text}"
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise exceptions.GitHubAPIError(
+            "Could not retrieve changelog from github: " + str(exc)
+        ) from exc
+
+    response_payload = response.json()
+    if "errors" in response_payload:
+        raise exceptions.GitHubAPIError(
+            "GitHub API error response: \n"
+            + "\n".join(e.get("message", str(e)) for e in response_payload["errors"])
+        )
+    return response_payload

--- a/sphinx_github_changelog/setup.py
+++ b/sphinx_github_changelog/setup.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import importlib.metadata
+import os
+
+from . import changelog, config
+
+
+def version() -> str:
+    return importlib.metadata.version("sphinx-github-changelog")
+
+
+def setup(app):
+    for name in config.ChangelogConfig.get_field_names():
+        option_name = f"{config.ChangelogConfig.prefix}_{name}"
+        app.add_config_value(
+            name=option_name,
+            default=os.environ.get(option_name.upper()),
+            rebuild="html",
+        )
+
+    app.add_directive("changelog", changelog.ChangelogDirective)
+
+    return {
+        "version": version(),
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/sphinx_github_changelog/urls.py
+++ b/sphinx_github_changelog/urls.py
@@ -6,105 +6,117 @@ Includes functions to parse remote URLs and derive GraphQL endpoints.
 
 from __future__ import annotations
 
+import dataclasses
+import pathlib
 import re
 import subprocess
+from typing import Self
 from urllib.parse import urlparse
 
-
-def parse_github_repo_from_url(url: str) -> str | None:
-    """Parse the owner/repo from a GitHub remote URL (https or ssh).
-
-    We also remove a trailing `/releases` if present as the expected usage
-    is with the URL of the GitHub releases page.
-
-    >>> parse_github_repo_from_url('https://github.com/org/repo')
-    'org/repo'
-    >>> parse_github_repo_from_url('https://github.com/org/repo/releases')
-    'org/repo'
-    """
-    if m := re.fullmatch(r"https?://[^/]+/([^/]+/[^/.]+)(?:/releases)?", url):
-        return m.group(1)
-    return None
+from . import config as config_module
+from . import exceptions
 
 
-def get_github_graphql_url(repo_url: str) -> str:
-    """Derive the GitHub GraphQL endpoint from a remote URL.
+@dataclasses.dataclass
+class GitHubParams:
+    hostname: str
+    owner: str
+    repo: str
 
-    >>> get_github_graphql_url('https://github.com/org/repo.git')
-    'https://api.github.com/graphql'
-    >>> get_github_graphql_url('https://github.enterprise.com/org/repo')
-    'https://github.enterprise.com/api/graphql'
-    """
-    host = get_github_host_from_url(repo_url) or "github.com"
-    if host == "github.com":
-        return "https://api.github.com/graphql"
-    return f"https://{host}/api/graphql"
+    @classmethod
+    def from_http_url(cls, url: str) -> Self:
+        parsed = urlparse(url)
+        if not parsed.hostname:
+            raise exceptions.CouldNotExtract(f"Configured URL ({url}) has no hostname")
+        try:
+            # 0 is /, and then 1, 2, ... are path elements.
+            owner, repo = pathlib.PurePosixPath(parsed.path).parts[1:3]
+        except ValueError as exc:
+            raise exceptions.CouldNotExtract(
+                f"Could not extract org and repository from URL {url}"
+            ) from exc
+
+        return cls(hostname=parsed.hostname, owner=owner, repo=repo)
+
+    @classmethod
+    def from_ssh_url(cls, url: str) -> Self:
+        """Parse a git SSH remote URL into GitHubParams.
+
+        >>> GitHubParams.from_ssh_url('git@github.com:org/repo.git')
+        GitHubParams(hostname='github.com', owner='org', repo='repo')
+        """
+        if not (
+            m := re.match(
+                r"git@(?P<hostname>[^:]+):(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$",
+                url,
+            )
+        ):
+            raise exceptions.CouldNotExtract(
+                f"Did not recognize github ssh remote url ({url})"
+            )
+        return cls(**m.groupdict())
+
+    @classmethod
+    def from_remote_urls(cls, urls: list[str]) -> Self:
+        excs: list[exceptions.CouldNotExtract] = []
+        for url in urls:
+            try:
+                if url.startswith("http"):
+                    return cls.from_http_url(url.removesuffix(".git"))
+                return cls.from_ssh_url(url)
+            except exceptions.CouldNotExtract as exc:
+                excs.append(exc)
+                continue
+        raise ExceptionGroup("All configured remotes have failed", excs)
+
+    @property
+    def is_github_com(self) -> bool:
+        return self.hostname == "github.com"
+
+    @property
+    def repo_url(self) -> str:
+        return f"https://{self.hostname}/{self.owner}/{self.repo}"
+
+    @property
+    def graphql_url(self) -> str:
+        if self.is_github_com:
+            return "https://api.github.com/graphql"
+        return f"https://{self.hostname}/api/graphql"
 
 
-def get_github_host_from_url(url: str) -> str:
-    """Extract the host from a GitHub remote URL.
+def extract_github_params(
+    options: config_module.ChangelogDirectiveOptions,
+    config: config_module.ChangelogConfig,
+) -> GitHubParams:
+    if options.github:
+        return GitHubParams.from_http_url(options.github)
 
-    >>> get_github_host_from_url('https://github.com/org/repo')
-    'github.com'
-    >>> get_github_host_from_url('https://github.enterprise.com/org/repo')
-    'github.enterprise.com'
-    """
-    parsed = urlparse(url)
-    return parsed.hostname or "github.com"
+    return GitHubParams.from_remote_urls(extract_remote_candidates())
 
 
-def get_root_url(url: str) -> str:
-    """Extract the root URL from a GitHub remote URL.
-
-    >>> get_root_url('https://github.com/org/repo')
-    'https://github.com/'
-    >>> get_root_url('https://github.enterprise.com/org/repo')
-    'https://github.enterprise.com/'
-    """
-    parsed = urlparse(url)
-    return f"{parsed.scheme}://{parsed.hostname or 'github.com'}/"
-
-
-def normalize_github_url(url: str) -> str | None:
-    """Normalize a git remote URL to a plain HTTPS URL without .git.
-
-    >>> normalize_github_url('git@github.com:org/repo.git')
-    'https://github.com/org/repo'
-    >>> normalize_github_url('https://github.enterprise.com/org/repo.git')
-    'https://github.enterprise.com/org/repo'
-    >>> normalize_github_url('https://github.com/org/repo')
-    'https://github.com/org/repo'
-    """
-    if m := re.match(r"git@([^:]+):([^/]+/[^/]+?)(?:\.git)?$", url):
-        host, repo = m.groups()
-        return f"https://{host}/{repo}"
-    parsed = urlparse(url)
-    if parsed.scheme in ("http", "https") and parsed.hostname and parsed.path:
-        path = parsed.path
-        if path.endswith(".git"):
-            path = path[:-4]
-        return f"{parsed.scheme}://{parsed.hostname}{path}"
-    return None
-
-
-def get_default_github_url() -> str | None:
+def extract_remote_candidates() -> list[str]:
     """Try to get the default GitHub remote URL from git remotes.
 
     Prefer upstream, then origin, if these are set and represent a
     GitHub remote.
     """
-    try:
-        remotes = subprocess.check_output(
-            ["git", "remote", "-v"],
-            text=True,
-        ).splitlines()
-        urls = {}
-        for line in remotes:
-            name, url, op = line.split(maxsplit=2)
-            if op != "(fetch)":
-                continue
-            if clean := normalize_github_url(url):
-                urls[name] = clean
-        return urls.get("upstream") or urls.get("origin")
-    except Exception:
-        return None
+
+    remotes = subprocess.check_output(["git", "remote", "-v"], text=True).splitlines()
+    urls: dict[str, str] = {}
+    for line in remotes:
+        name, url, op = line.split(maxsplit=2)
+        if op != "(fetch)":
+            continue
+        urls[name] = url
+
+    if not urls:
+        raise exceptions.CouldNotExtract("No fetch URL found in remotes")
+
+    return [
+        url
+        for _, url in sorted(
+            urls.items(),
+            key=lambda kv: (kv[0] == "upstream", kv[0] == "origin"),
+            reverse=True,
+        )
+    ]

--- a/tests/acceptance/test_all.py
+++ b/tests/acceptance/test_all.py
@@ -95,7 +95,7 @@ def test_build(app, httpx_mock, full_gfm_release_dict):
     received = (app.outdir / "index.html").read_text()
     print(received)
     query = json.loads(httpx_mock.get_requests()[0].content)["query"]
-    assert query.lstrip().startswith("query {")
+    assert "query($owner: String!, $repo: String!)" in query
     assert expected in received
 
 
@@ -103,7 +103,6 @@ def test_build(app, httpx_mock, full_gfm_release_dict):
 def test_error(app, status, warning):
     app.builder.build_all()
     assert (
-        "Changelog needs a Github releases URL "
-        "(https://wrong-url.com/:owner/:repo/releases). "
-        "Received https://wrong-url.com/" in warning.getvalue()
+        "No :github: release URL provided and unable to determine it from "
+        "git remotes." in warning.getvalue()
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import os
 import subprocess
 from pathlib import Path
 
 import pytest
+
+from sphinx_github_changelog import github_releases
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -27,17 +28,19 @@ def release_dict():
 
 
 @pytest.fixture
+def release(release_dict):
+    return github_releases.Release.from_graphql(release_dict)
+
+
+@pytest.fixture
 def github_payload(release_dict):
     return {"data": {"repository": {"releases": {"nodes": [release_dict]}}}}
 
 
 @pytest.fixture(autouse=True)
-def env():
-    old_env = os.environ.copy()
-    os.environ.pop("SPHINX_GITHUB_CHANGELOG_TOKEN", None)
-    yield os.environ
-    os.environ.clear()
-    os.environ.update(old_env)
+def env(monkeypatch):
+    monkeypatch.delenv("SPHINX_GITHUB_CHANGELOG_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
 
 @pytest.fixture

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 import re
 import xml.dom.minidom
 
-import httpx
 import pytest
 
-from sphinx_github_changelog import changelog, credentials
+from sphinx_github_changelog import changelog, credentials, exceptions
+from sphinx_github_changelog import config as config_module
 
 
 @pytest.fixture
-def extract_releases(mocker, release_dict):
+def extract_releases(mocker, release):
     return mocker.patch(
-        "sphinx_github_changelog.changelog.extract_releases",
-        return_value=[release_dict],
+        "sphinx_github_changelog.github_releases.extract_releases",
+        return_value=[release],
     )
 
 
@@ -44,28 +44,37 @@ def canonicalize(value):
 
 
 def test_compute_changelog_no_token(monkeypatch):
-    monkeypatch.setattr(credentials, "get_github_token", lambda host: None)
-    nodes = changelog.compute_changelog(
-        token=None, options={"github": "https://github.com/a/b/releases"}
+    def raise_no_token(host):
+        raise exceptions.CouldNotExtract("No GitHub token found")
+
+    monkeypatch.setattr(credentials, "get_github_token", raise_no_token)
+    options = config_module.ChangelogDirectiveOptions(
+        github="https://github.com/a/b/releases",
     )
+    config = config_module.ChangelogConfig()
+    nodes = changelog.compute_changelog(options=options, config=config)
     assert "Changelog was not built" in node_to_string(nodes[0])
 
 
 def test_compute_changelog_no_url(temp_git):
     with pytest.raises(
-        changelog.ChangelogError,
+        exceptions.ChangelogError,
         match=(
             r"^No :github: release URL provided and unable to determine it from "
             r"git remotes. "
         ),
     ):
-        changelog.compute_changelog(token=None, options={})
+        options = config_module.ChangelogDirectiveOptions()
+        config = config_module.ChangelogConfig()
+        changelog.compute_changelog(options=options, config=config)
 
 
 def test_compute_changelog_token(extract_releases):
-    nodes = changelog.compute_changelog(
-        token="token", options={"github": "https://github.com/a/b/releases"}
+    options = config_module.ChangelogDirectiveOptions(
+        github="https://github.com/a/b/releases",
     )
+    config = config_module.ChangelogConfig(token="token")
+    nodes = changelog.compute_changelog(options=options, config=config)
     assert "1.0.0: A new hope" in node_to_string(nodes[0])
 
 
@@ -123,41 +132,6 @@ def test_no_token_url():
 
 
 @pytest.mark.parametrize(
-    "url", ["https://github.com/a/b/releases", "https://github.com/a/b/releases/"]
-)
-def test_extract_github_repo_name(url):
-    assert changelog.extract_github_repo_name(url) == "a/b"
-
-
-def test_extract_github_repo_name_error():
-    with pytest.raises(
-        changelog.ChangelogError, match=r"^Changelog needs a Github releases URL"
-    ):
-        changelog.extract_github_repo_name("https://example.com")
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://git.privaterepo.com/a/b/releases",
-        "https://git.privaterepo.com/a/b/releases/",
-    ],
-)
-def test_extract_github_repo_different_root_url(url):
-    with pytest.raises(
-        changelog.ChangelogError, match=r"^Changelog needs a Github releases URL"
-    ):
-        changelog.extract_github_repo_name(url)
-
-    assert (
-        changelog.extract_github_repo_name(url, "https://git.privaterepo.com/") == "a/b"
-    )
-    assert (
-        changelog.extract_github_repo_name(url, "https://git.privaterepo.com") == "a/b"
-    )
-
-
-@pytest.mark.parametrize(
     "url", ["https://pypi.org/project/a", "https://pypi.org/project/a/"]
 )
 def test_extract_pypi_package_name(url):
@@ -166,14 +140,14 @@ def test_extract_pypi_package_name(url):
 
 def test_extract_pypi_package_name_error():
     with pytest.raises(
-        changelog.ChangelogError, match=r"^Changelog needs a PyPI project URL"
+        exceptions.ChangelogError, match=r"^Changelog needs a PyPI project URL"
     ):
         changelog.extract_pypi_package_name("https://example.com")
 
 
-def test_node_for_release_no_pypi(release_dict):
+def test_node_for_release_no_pypi(release):
     assert node_to_string(
-        changelog.node_for_release(release=release_dict, pypi_name=None)
+        changelog.node_for_release(release=release, pypi_name=None)
     ) == canonicalize(
         """
         <section ids="release-1-0-0">
@@ -189,24 +163,22 @@ def test_node_for_release_no_pypi(release_dict):
     )
 
 
-def test_node_for_release_title_tag(release_dict):
-    release_dict["name"] = "Bla 1.0.0"
+def test_node_for_release_title_tag(release):
+    release.name = "Bla 1.0.0"
     assert "<title>Bla 1.0.0</title>" in node_to_string(
-        changelog.node_for_release(release=release_dict, pypi_name=None)
+        changelog.node_for_release(release=release, pypi_name=None)
     )
 
 
-def test_node_for_release_none_title(release_dict):
-    release_dict["name"] = None
+def test_node_for_release_none_title(release):
+    release.name = None
     assert "<title>1.0.0</title>" in node_to_string(
-        changelog.node_for_release(release=release_dict, pypi_name=None)
+        changelog.node_for_release(release=release, pypi_name=None)
     )
 
 
-def test_node_for_release_title_pypy(release_dict):
-    value = node_to_string(
-        changelog.node_for_release(release=release_dict, pypi_name="foo")
-    )
+def test_node_for_release_title_pypy(release):
+    value = node_to_string(changelog.node_for_release(release=release, pypi_name="foo"))
 
     assert (
         """<reference refuri="https://pypi.org/project/foo/1.0.0/">PyPI</reference>"""
@@ -214,93 +186,9 @@ def test_node_for_release_title_pypy(release_dict):
     )
 
 
-def test_node_for_release_draft(release_dict):
-    release_dict["isDraft"] = True
-    assert changelog.node_for_release(release=release_dict, pypi_name="foo") is None
-
-
-def test_extract_releases(github_payload, release_dict, mocker):
-    mocker.patch(
-        "sphinx_github_changelog.changelog.github_call", return_value=github_payload
-    )
-    assert changelog.extract_releases(owner_repo="a/b", token="token") == [
-        release_dict,
-    ]
-
-
-def test_extract_releases_custom_graphql_url(github_payload, release_dict, mocker):
-    mocker.patch(
-        "sphinx_github_changelog.changelog.github_call", return_value=github_payload
-    )
-    assert changelog.extract_releases(
-        owner_repo="a/b",
-        token="token",
-        graphql_url="https://git.privaterepo.com/graphql",
-    ) == [
-        release_dict,
-    ]
-
-
-def test_extract_releases_remove_none(github_payload, release_dict, mocker):
-    mocker.patch(
-        "sphinx_github_changelog.changelog.github_call",
-        return_value={
-            "data": {"repository": {"releases": {"nodes": [None, 1, None, 2]}}}
-        },
-    )
-    assert changelog.extract_releases(owner_repo="a/b", token="token") == [1, 2]
-
-
-def test_extract_releases_errors(github_payload, release_dict, mocker):
-    mocker.patch(
-        "sphinx_github_changelog.changelog.github_call",
-        return_value={"errors": [{"message": "c"}, {"message": "d"}]},
-    )
-    with pytest.raises(changelog.ChangelogError) as exc_info:
-        changelog.extract_releases(owner_repo="a/b", token="token")
-
-    assert str(exc_info.value) == "GitHub API error response: \nc\nd"
-
-
-def test_extract_releases_format(github_payload, release_dict, mocker):
-    mocker.patch(
-        "sphinx_github_changelog.changelog.github_call",
-        return_value={"data": {"repository": None}},
-    )
-    with pytest.raises(changelog.ChangelogError) as exc_info:
-        changelog.extract_releases(owner_repo="a/b", token="token")
-
-    error = "GitHub API error unexpected format:\n{'data': {'repository': None}}"
-    assert str(exc_info.value) == error
-
-
-def test_github_call(httpx_mock):
-    url = "https://api.github.com/graphql"
-    payload = {"message": "foo"}
-    httpx_mock.add_response(url=url, method="POST", json=payload)
-    assert changelog.github_call(url=url, token="token", query="") == payload
-
-
-def test_github_call_http_error(httpx_mock):
-    url = "https://api.github.com/graphql"
-    httpx_mock.add_response(
-        url=url, method="POST", status_code=400, json={"message": "foo"}
-    )
-    with pytest.raises(changelog.ChangelogError) as exc_info:
-        changelog.github_call(url=url, token="token", query="")
-
-    assert str(exc_info.value) == (
-        "Unexpected GitHub API error status code: 400\n" """{"message":"foo"}"""
-    )
-
-
-def test_github_call_http_error_connection(httpx_mock):
-    url = "https://api.github.com/graphql"
-    httpx_mock.add_exception(httpx.ConnectError("bar"), url=url, method="POST")
-    with pytest.raises(changelog.ChangelogError) as exc_info:
-        changelog.github_call(url=url, token="token", query="")
-
-    assert str(exc_info.value) == "Could not retrieve changelog from github: bar"
+def test_node_for_release_draft(release):
+    release.is_draft = True
+    assert changelog.node_for_release(release=release, pypi_name="foo") is None
 
 
 @pytest.mark.parametrize(
@@ -323,57 +211,6 @@ def test_get_token_from_env(monkeypatch):
     assert credentials.get_token_from_env() is None
 
 
-def test_transforms_private_image_url():
-    html = (
-        '<img src="https://private-user-images.githubusercontent.com/'
-        "123/456789-abcd1234-5678-90ab-cdef-123456789012.png"
-        '?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9&amp;exp=1234567890">'
-    )
-    result = changelog.transform_private_image_urls(html)
-    assert result == (
-        '<img src="https://github.com/user-attachments/assets/'
-        'abcd1234-5678-90ab-cdef-123456789012">'
-    )
-
-
-def test_transforms_multiple_urls():
-    html = (
-        '<img src="https://private-user-images.githubusercontent.com/'
-        '123/111-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.png?jwt=token1">'
-        '<img src="https://private-user-images.githubusercontent.com/'
-        '456/222-11111111-2222-3333-4444-555555555555.jpg?jwt=token2">'
-    )
-    result = changelog.transform_private_image_urls(html)
-    assert (
-        "https://github.com/user-attachments/assets/"
-        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-    ) in result
-    assert (
-        "https://github.com/user-attachments/assets/"
-        "11111111-2222-3333-4444-555555555555"
-    ) in result
-    assert "private-user-images" not in result
-
-
-def test_preserves_other_urls():
-    html = (
-        '<img src="https://example.com/image.png">'
-        '<a href="https://github.com/repo">link</a>'
-    )
-    result = changelog.transform_private_image_urls(html)
-    assert result == html
-
-
-def test_handles_empty_string():
-    assert changelog.transform_private_image_urls("") == ""
-
-
-def test_handles_html_without_images():
-    html = "<p>No images here</p>"
-    result = changelog.transform_private_image_urls(html)
-    assert result == html
-
-
 ALERT_MARKDOWN = """Regular content
 
 > [!NOTE]
@@ -381,16 +218,22 @@ ALERT_MARKDOWN = """Regular content
 """
 
 
-def test_converts_alerts_by_default(release_dict):
-    release_dict["description"] = ALERT_MARKDOWN
-    result = changelog.node_for_release(release=release_dict, pypi_name=None)
+def test_converts_alerts_by_default(release):
+    release.description = ALERT_MARKDOWN
+    result = changelog.node_for_release(release=release, pypi_name=None)
     result_str = node_to_string(result)
     assert "<note>" in result_str
 
 
-def test_preserves_non_alert_content(release_dict):
-    release_dict["description"] = ALERT_MARKDOWN
-    result = changelog.node_for_release(release=release_dict, pypi_name=None)
+def test_preserves_non_alert_content(release):
+    release.description = ALERT_MARKDOWN
+    result = changelog.node_for_release(release=release, pypi_name=None)
     result_str = node_to_string(result)
     # Regular content should still be present
     assert "Regular content" in result_str
+
+
+def test_convert_markdown_to_nodes_empty():
+    assert changelog.convert_markdown_to_nodes(None) == []
+    assert changelog.convert_markdown_to_nodes("") == []
+    assert changelog.convert_markdown_to_nodes("   ") == []

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -7,12 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from sphinx_github_changelog import urls
-from sphinx_github_changelog.credentials import (
-    get_token_from_gh_cli,
-    get_token_from_git_credential,
-    is_github_token,
-)
+from sphinx_github_changelog import credentials, exceptions, urls
 
 
 def git(*args: str) -> str:
@@ -28,25 +23,24 @@ def add_remote(name: str, url: str):
 def test_get_git_remote_origin(temp_git: Path):
     """Test for getting the GitHub URL from the origin remote."""
     add_remote("origin", "https://github.com/ewjoachim/sphinx-github-changelog.git")
-    assert (
-        urls.get_default_github_url()
-        == "https://github.com/ewjoachim/sphinx-github-changelog"
-    )
+    candidates = urls.extract_remote_candidates()
+    params = urls.GitHubParams.from_remote_urls(candidates)
+    assert params.repo_url == "https://github.com/ewjoachim/sphinx-github-changelog"
 
 
 def test_get_git_remote_upstream(temp_git: Path):
-    """Test for getting the GitHub URL from the upsteam remote."""
+    """Test for getting the GitHub URL from the upstream remote."""
     add_remote("origin", "https://github.com/lordmauve/sphinx-github-changelog.git")
     add_remote("upstream", "https://github.com/ewjoachim/sphinx-github-changelog.git")
-    assert (
-        urls.get_default_github_url()
-        == "https://github.com/ewjoachim/sphinx-github-changelog"
-    )
+    candidates = urls.extract_remote_candidates()
+    params = urls.GitHubParams.from_remote_urls(candidates)
+    assert params.repo_url == "https://github.com/ewjoachim/sphinx-github-changelog"
 
 
 def test_get_git_no_remotes(temp_git: Path):
     """We can't get a GitHub URL if no remotes are set."""
-    assert urls.get_default_github_url() is None
+    with pytest.raises(exceptions.CouldNotExtract, match="No fetch URL found"):
+        urls.extract_remote_candidates()
 
 
 @pytest.fixture
@@ -75,20 +69,20 @@ def test_git_credential(credential_file: Path):
     """Test for getting a git token from the git credential helper."""
     credential_file.write_text("https://x:gho_1234abcd@github.com\n")
 
-    assert get_token_from_git_credential("github.com") == "gho_1234abcd"
+    assert credentials.get_token_from_git_credential("github.com") == "gho_1234abcd"
 
 
 def test_git_credential_password(credential_file: Path):
     """We do not attempt to use a password that does not look like a token."""
     credential_file.write_text("https://ewjoachim:hunter2@github.com\n")
 
-    assert get_token_from_git_credential("github.com") is None
+    assert credentials.get_token_from_git_credential("github.com") is None
 
 
 def test_git_credential_unavailable(credential_file: Path):
     """We return None if no git credentials are available."""
     credential_file.write_text("\n")
-    assert get_token_from_git_credential("github.com") is None
+    assert credentials.get_token_from_git_credential("github.com") is None
 
 
 @pytest.mark.parametrize(
@@ -101,7 +95,7 @@ def test_git_credential_unavailable(credential_file: Path):
     ],
 )
 def test_is_github_token(token, expected):
-    assert is_github_token(token) == expected
+    assert credentials.is_github_token(token) == expected
 
 
 def test_get_token_from_gh(fake_process):
@@ -113,4 +107,26 @@ def test_get_token_from_gh(fake_process):
     fake_process.register(
         ["gh", "auth", "token", "--hostname=github.com"], stdout="ghx_123"
     )
-    assert get_token_from_gh_cli("github.com") == "ghx_123"
+    assert credentials.get_token_from_gh_cli("github.com") == "ghx_123"
+
+
+def test_get_token_from_gh_empty(fake_process):
+    """gh auth token returning empty output should return None."""
+    fake_process.register(["gh", "auth", "token", "--hostname=github.com"], stdout="")
+    assert credentials.get_token_from_gh_cli("github.com") is None
+
+
+def test_get_github_token_from_env(monkeypatch):
+    """get_github_token should return a token from environment."""
+    monkeypatch.setenv("SPHINX_GITHUB_CHANGELOG_TOKEN", "gho_envtoken")
+    assert credentials.get_github_token("github.com") == "gho_envtoken"
+
+
+def test_get_github_token_not_found(monkeypatch, fake_process):
+    """get_github_token should raise CouldNotExtract when no token is found."""
+    monkeypatch.delenv("SPHINX_GITHUB_CHANGELOG_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    fake_process.register(["git", "credential", "fill"], stdout="")
+    fake_process.register(["gh", "auth", "token", "--hostname=github.com"], stdout="")
+    with pytest.raises(exceptions.CouldNotExtract, match="No GitHub token found"):
+        credentials.get_github_token("github.com")

--- a/tests/unit/test_github_releases.py
+++ b/tests/unit/test_github_releases.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from sphinx_github_changelog import exceptions, github_releases, urls
+
+
+@pytest.fixture
+def github_params():
+    return urls.GitHubParams(hostname="github.com", owner="a", repo="b")
+
+
+def test_extract_releases(github_payload, release, github_params, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json=github_payload,
+    )
+    assert github_releases.extract_releases(
+        github_params=github_params, token="token"
+    ) == [release]
+
+
+def test_extract_releases_custom_graphql_url(
+    github_payload, release, github_params, httpx_mock
+):
+    httpx_mock.add_response(
+        url="https://git.privaterepo.com/graphql",
+        method="POST",
+        json=github_payload,
+    )
+    assert github_releases.extract_releases(
+        github_params=github_params,
+        token="token",
+        graphql_url="https://git.privaterepo.com/graphql",
+    ) == [release]
+
+
+def test_extract_releases_remove_none(github_params, httpx_mock, release_dict):
+    release_dict_2 = release_dict.copy()
+    release_dict_2["name"] = "Second"
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={
+            "data": {
+                "repository": {
+                    "releases": {"nodes": [None, release_dict, None, release_dict_2]}
+                }
+            }
+        },
+    )
+    result = github_releases.extract_releases(
+        github_params=github_params, token="token"
+    )
+    assert len(result) == 2
+
+
+def test_extract_releases_format(github_params, httpx_mock):
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        method="POST",
+        json={"data": {"repository": None}},
+    )
+    with pytest.raises(exceptions.GitHubAPIError) as exc_info:
+        github_releases.extract_releases(github_params=github_params, token="token")
+
+    error = "GitHub API error unexpected format:\n{'data': {'repository': None}}"
+    assert str(exc_info.value) == error
+
+
+def test_github_call(httpx_mock):
+    url = "https://api.github.com/graphql"
+    payload = {"message": "foo"}
+    httpx_mock.add_response(url=url, method="POST", json=payload)
+    assert (
+        github_releases.github_call(url=url, token="token", payload={"query": ""})
+        == payload
+    )
+
+
+def test_github_call_errors(httpx_mock):
+    url = "https://api.github.com/graphql"
+    httpx_mock.add_response(
+        url=url,
+        method="POST",
+        json={"errors": [{"message": "c"}, {"message": "d"}]},
+    )
+    with pytest.raises(exceptions.GitHubAPIError) as exc_info:
+        github_releases.github_call(url=url, token="token", payload={"query": ""})
+
+    assert str(exc_info.value) == "GitHub API error response: \nc\nd"
+
+
+def test_github_call_http_error(httpx_mock):
+    url = "https://api.github.com/graphql"
+    httpx_mock.add_response(
+        url=url, method="POST", status_code=400, json={"message": "foo"}
+    )
+    with pytest.raises(exceptions.GitHubAPIError) as exc_info:
+        github_releases.github_call(url=url, token="token", payload={"query": ""})
+
+    assert str(exc_info.value) == (
+        "Unexpected GitHub API error status code: 400\n" """{"message":"foo"}"""
+    )
+
+
+def test_github_call_http_error_connection(httpx_mock):
+    url = "https://api.github.com/graphql"
+    httpx_mock.add_exception(httpx.ConnectError("bar"), url=url, method="POST")
+    with pytest.raises(exceptions.GitHubAPIError) as exc_info:
+        github_releases.github_call(url=url, token="token", payload={"query": ""})
+
+    assert str(exc_info.value) == "Could not retrieve changelog from github: bar"

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -4,82 +4,100 @@ from __future__ import annotations
 
 import pytest
 
-from sphinx_github_changelog.urls import (
-    get_github_graphql_url,
-    get_github_host_from_url,
-    get_root_url,
-    normalize_github_url,
-    parse_github_repo_from_url,
-)
+from sphinx_github_changelog import exceptions, urls
 
 
 @pytest.mark.parametrize(
-    "url, expected",
+    "url, expected_owner, expected_repo",
     [
-        ("https://github.com/org/repo", "org/repo"),
-        ("https://github.enterprise.com/org/repo", "org/repo"),
-        ("https://github.com/org/repo/releases", "org/repo"),
-        ("not-a-github-url", None),
+        ("https://github.com/org/repo", "org", "repo"),
+        ("https://github.enterprise.com/org/repo", "org", "repo"),
+        ("https://github.com/org/repo/releases", "org", "repo"),
+        ("https://github.com/org/repo/releases/", "org", "repo"),
     ],
 )
-def test_parse_github_repo_from_url(url: str, expected: str | None) -> None:
-    """Should extract 'owner/repo' or return None for invalid URLs."""
-    assert parse_github_repo_from_url(url) == expected
+def test_from_http_url(url, expected_owner, expected_repo):
+    params = urls.GitHubParams.from_http_url(url)
+    assert params.owner == expected_owner
+    assert params.repo == expected_repo
+
+
+def test_from_http_url_no_hostname():
+    with pytest.raises(exceptions.CouldNotExtract, match="has no hostname"):
+        urls.GitHubParams.from_http_url("not-a-url")
+
+
+def test_from_http_url_no_path():
+    with pytest.raises(exceptions.CouldNotExtract, match="Could not extract"):
+        urls.GitHubParams.from_http_url("https://github.com/")
 
 
 @pytest.mark.parametrize(
-    "url, expected",
+    "url, expected_hostname, expected_owner, expected_repo",
     [
-        ("https://github.com/org/repo.git", "https://api.github.com/graphql"),
+        ("git@github.com:org/repo.git", "github.com", "org", "repo"),
+        ("git@github.com:org/repo", "github.com", "org", "repo"),
         (
-            "https://github.enterprise.com/org/repo",
-            "https://github.enterprise.com/api/graphql",
+            "git@github.enterprise.com:org/repo.git",
+            "github.enterprise.com",
+            "org",
+            "repo",
         ),
-        ("not-a-github-url", "https://api.github.com/graphql"),
     ],
 )
-def test_get_github_graphql_url(url: str, expected: str | None) -> None:
-    """Should derive the correct GraphQL endpoint or None for invalid URLs."""
-    assert get_github_graphql_url(url) == expected
+def test_from_ssh_url(url, expected_hostname, expected_owner, expected_repo):
+    params = urls.GitHubParams.from_ssh_url(url)
+    assert params.hostname == expected_hostname
+    assert params.owner == expected_owner
+    assert params.repo == expected_repo
 
 
-@pytest.mark.parametrize(
-    "url, expected",
-    [
-        ("https://github.com/org/repo", "github.com"),
-        ("https://github.enterprise.com/org/repo", "github.enterprise.com"),
-    ],
-)
-def test_get_github_host_from_url(url: str, expected: str) -> None:
-    """Should return the GitHub host name from the URL."""
-    assert get_github_host_from_url(url) == expected
+def test_from_ssh_url_invalid():
+    with pytest.raises(exceptions.CouldNotExtract, match="Did not recognize"):
+        urls.GitHubParams.from_ssh_url("not-a-url")
 
 
-@pytest.mark.parametrize(
-    "url, expected",
-    [
-        ("https://github.com/org/repo", "https://github.com/"),
-        ("https://github.enterprise.com/org/repo", "https://github.enterprise.com/"),
-    ],
-)
-def test_get_root_url(url: str, expected: str) -> None:
-    """Should return the root URL (scheme + host + slash)."""
-    assert get_root_url(url) == expected
+def test_from_remote_urls_http():
+    params = urls.GitHubParams.from_remote_urls(["https://github.com/org/repo.git"])
+    assert params.owner == "org"
+    assert params.repo == "repo"
 
 
-@pytest.mark.parametrize(
-    "url, expected",
-    [
-        ("git@github.com:org/repo.git", "https://github.com/org/repo"),
-        (
-            "https://github.enterprise.com/org/repo.git",
-            "https://github.enterprise.com/org/repo",
-        ),
-        ("https://github.com/org/repo", "https://github.com/org/repo"),
-        ("git@github.com:org/repo", "https://github.com/org/repo"),
-        ("not-a-github-url", None),
-    ],
-)
-def test_normalize_github_url(url: str, expected: str) -> None:
-    """Should normalize SSH and HTTP(S) GitHub URLs to plain HTTPS."""
-    assert normalize_github_url(url) == expected
+def test_from_remote_urls_ssh():
+    params = urls.GitHubParams.from_remote_urls(["git@github.com:org/repo.git"])
+    assert params.owner == "org"
+    assert params.repo == "repo"
+
+
+def test_from_remote_urls_all_invalid():
+    with pytest.raises(ExceptionGroup):
+        urls.GitHubParams.from_remote_urls(["not-a-url", "also-not-a-url"])
+
+
+def test_is_github_com():
+    params = urls.GitHubParams(hostname="github.com", owner="org", repo="repo")
+    assert params.is_github_com is True
+
+
+def test_is_not_github_com():
+    params = urls.GitHubParams(
+        hostname="github.enterprise.com", owner="org", repo="repo"
+    )
+    assert params.is_github_com is False
+
+
+def test_repo_url():
+    params = urls.GitHubParams(hostname="github.com", owner="org", repo="repo")
+    assert params.repo_url == "https://github.com/org/repo"
+
+
+def test_graphql_url_github_com():
+    params = urls.GitHubParams(hostname="github.com", owner="org", repo="repo")
+    assert params.graphql_url == "https://api.github.com/graphql"
+
+
+def test_graphql_url_enterprise():
+    params = urls.GitHubParams(
+        hostname="github.enterprise.com", owner="org", repo="repo"
+    )
+    assert params.graphql_url == "https://github.enterprise.com/api/graphql"


### PR DESCRIPTION
(Note: mostly handwritten, but a LLM was used to review and add some fixes, split and write correct commit messages)

## Refactor into separate modules & achieve 100% test coverage

Break down the monolithic changelog.py into focused modules, improve testability, and reach 100% coverage (279 statements, 48 branches, 63 tests).

### Changes

**New modules extracted from changelog.py:**
- `config.py`: `ChangelogDirectiveOptions` and `ChangelogConfig` dataclasses
- `exceptions.py`: `ChangelogError`, `CouldNotExtract`, `GitHubAPIError`
- `github_releases.py`: `Release` dataclass, `extract_releases()`, `github_call()`
- `setup.py`: Sphinx `setup()` function, moved out of `__init__.py`

**Rewritten modules:**
- `urls.py`: `GitHubParams` dataclass with `from_http_url()`, `from_ssh_url()`, `from_remote_urls()` classmethods, replacing loose URL-parsing functions.
- `credentials.py`: `get_github_token()` now raises `CouldNotExtract` instead of returning `None`. (Also checks `GITHUB_TOKEN` env var as fallback)
- `changelog.py`: delegates to the extracted modules, use typed dataclasses instead of raw dicts.

**Other:**
- `pyproject.toml`: remove redundant `ruff target-version` (inferred from `requires-python`)
- `README.rst`: document token resolution order, add `GITHUB_TOKEN` fallback, clarify ReadTheDocs requirements
- GraphQL queries now use parameterized variables instead of string interpolation
- `transform_private_image_urls` removed (GraphQL `description` field returns markdown with permanent URLs)

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
