### PR TITLE
fix: strip 'v' prefix from tags in titles, section IDs, and PyPI URLs

### DIFF
--- a/sphinx_github_changelog/changelog.py
+++ b/sphinx_github_changelog/changelog.py
@@ -113,9 +113,10 @@ def extract_pypi_package_name(url: str | None) -> str | None:
 
 
 def get_release_title(title: str | None, tag: str):
+    version = tag.removeprefix("v")
     if not title:
-        return tag
-    return title if tag in title else f"{tag}: {title}"
+        return version
+    return title if version in title else f"{version}: {title}"
 
 
 def node_for_release(
@@ -126,12 +127,13 @@ def node_for_release(
         return None  # For now, draft releases are excluded
 
     tag = release.tag_name
+    version = tag.removeprefix("v")
     title = release.name
     date = release.published_at.isoformat()
     title = get_release_title(title=title, tag=tag)
 
     # Section
-    id_section = nodes.make_id("release-" + tag)
+    id_section = nodes.make_id("release-" + version)
     section = nodes.section(ids=[id_section])
 
     section += nodes.title(text=title)
@@ -143,7 +145,7 @@ def node_for_release(
     subtitle += nodes.reference("", "GitHub", refuri=release.url)
     if pypi_name:
         subtitle += nodes.Text(" - ")
-        url = f"https://pypi.org/project/{pypi_name}/{tag}/"
+        url = f"https://pypi.org/project/{pypi_name}/{version}/"
         subtitle += nodes.reference("", "PyPI", refuri=url)
 
     subtitle_paragraph = nodes.paragraph()

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -198,6 +198,9 @@ def test_node_for_release_draft(release):
         ("1.0.0: Foo", "1.0.0", "1.0.0: Foo"),
         ("Fix 1.0.0", "1.0.1", "1.0.1: Fix 1.0.0"),
         (None, "1.0.0", "1.0.0"),
+        ("Foo", "v1.0.0", "1.0.0: Foo"),
+        ("1.0.0: Foo", "v1.0.0", "1.0.0: Foo"),
+        (None, "v1.0.0", "1.0.0"),
     ],
 )
 def test_get_release_title(title, tag, expected):


### PR DESCRIPTION
Tags like 'v1.0.0' are now displayed as '1.0.0' in release titles, used without the prefix in section anchors, and generate correct PyPI URLs.

Closes #140

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
