### PR TITLE
feat: add option to exclude pre-releases from changelog

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,15 +178,29 @@ environment variable. You can also set the token as ``sphinx_github_changelog_to
 Extension options (``conf.py``)
 -------------------------------
 
-- ``sphinx_github_changelog_token`` (optional): GitHub API token, if needed, see above
-  (please do **NOT** commit your secrets).
+All options can also be set via environment variables of the same name in uppercase
+(e.g. ``SPHINX_GITHUB_CHANGELOG_TOKEN``).
 
-The following options are useful in some cases, though most of the time, the
-corresponding values will be detected automatically from the ``:github:`` parameter
-passed to the directive:
+.. list-table::
+   :header-rows: 1
+   :widths: 30 10 60
 
-- ``sphinx_github_changelog_root_repo`` (optional): Root URL to the repository.
-- ``sphinx_github_changelog_graphql_url`` (optional): URL to GraphQL API.
+   * - Option
+     - Default
+     - Description
+   * - ``sphinx_github_changelog_token``
+     - ``None``
+     - GitHub API token. See above (please do **NOT** commit your secrets).
+   * - ``sphinx_github_changelog_root_repo``
+     - ``None``
+     - Root URL to the repository. Usually detected automatically.
+   * - ``sphinx_github_changelog_graphql_url``
+     - ``None``
+     - URL to GraphQL API. Usually detected automatically.
+   * - ``sphinx_github_changelog_include_prereleases``
+     - ``True``
+     - Whether to include pre-releases in the changelog. Set to ``False``
+       to exclude them (env var accepts ``0``, ``false``, ``no``).
 
 .. _ReadTheDocs: https://readthedocs.org/
 

--- a/sphinx_github_changelog/changelog.py
+++ b/sphinx_github_changelog/changelog.py
@@ -64,6 +64,9 @@ def compute_changelog(
 
     pypi_name = extract_pypi_package_name(url=options.pypi)
 
+    if not config.include_prereleases:
+        releases = [r for r in releases if not r.is_prerelease]
+
     result_nodes = (
         node_for_release(release=release, pypi_name=pypi_name) for release in releases
     )

--- a/sphinx_github_changelog/config.py
+++ b/sphinx_github_changelog/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import dataclasses
+import os
+from collections.abc import Iterator
 from typing import Any, ClassVar
 
 
@@ -24,12 +26,24 @@ class ChangelogConfig:
     token: str | None = None
     root_repo: str | None = None
     graphql_url: str | None = None
+    include_prereleases: bool = True
 
     prefix: ClassVar[str] = "sphinx_github_changelog"
 
     @classmethod
-    def get_field_names(cls) -> list[str]:
-        return [f.name for f in dataclasses.fields(cls)]
+    def get_config_defaults(cls) -> Iterator[tuple[str, str | bool | None]]:
+        for field in dataclasses.fields(cls):
+            option_name = f"{cls.prefix}_{field.name}"
+            env_value = os.environ.get(option_name.upper())
+            if field.type == "bool":
+                default: str | bool | None = (
+                    env_value.lower() not in ("0", "false", "no")
+                    if env_value
+                    else bool(field.default)
+                )
+            else:
+                default = env_value
+            yield option_name, default
 
     @classmethod
     def from_sphinx_env_config(cls, sphinx_config: Any):
@@ -37,4 +51,5 @@ class ChangelogConfig:
             token=sphinx_config.sphinx_github_changelog_token,
             root_repo=sphinx_config.sphinx_github_changelog_root_repo,
             graphql_url=sphinx_config.sphinx_github_changelog_graphql_url,
+            include_prereleases=sphinx_config.sphinx_github_changelog_include_prereleases,
         )

--- a/sphinx_github_changelog/github_releases.py
+++ b/sphinx_github_changelog/github_releases.py
@@ -17,6 +17,7 @@ class Release:
     tag_name: str
     published_at: datetime.date
     is_draft: bool
+    is_prerelease: bool
 
     @classmethod
     def from_graphql(cls, data: dict) -> Release:
@@ -27,6 +28,7 @@ class Release:
             tag_name=data["tagName"],
             published_at=datetime.date.fromisoformat(data["publishedAt"][:10]),
             is_draft=data["isDraft"],
+            is_prerelease=data["isPrerelease"],
         )
 
 
@@ -40,7 +42,7 @@ def extract_releases(
         repository(owner: $owner, name: $repo) {
             releases(orderBy: {field: CREATED_AT, direction: DESC}, first:100) {
                 nodes {
-                    name, description, url, tagName, publishedAt, isDraft
+                    name, description, url, tagName, publishedAt, isDraft, isPrerelease
                 }
             }
         }

--- a/sphinx_github_changelog/setup.py
+++ b/sphinx_github_changelog/setup.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib.metadata
-import os
 
 from . import changelog, config
 
@@ -11,11 +10,10 @@ def version() -> str:
 
 
 def setup(app):
-    for name in config.ChangelogConfig.get_field_names():
-        option_name = f"{config.ChangelogConfig.prefix}_{name}"
+    for option_name, default in config.ChangelogConfig.get_config_defaults():
         app.add_config_value(
             name=option_name,
-            default=os.environ.get(option_name.upper()),
+            default=default,
             rebuild="html",
         )
 

--- a/tests/acceptance/test_all.py
+++ b/tests/acceptance/test_all.py
@@ -79,6 +79,7 @@ Let's rename \*our-new-project\* to \*our-old-project\*.
         "tagName": "1.0.0",
         "publishedAt": "2000-01-01",
         "isDraft": False,
+        "isPrerelease": False,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def release_dict():
         "tagName": "1.0.0",
         "publishedAt": "2000-01-01",
         "isDraft": False,
+        "isPrerelease": False,
     }
 
 

--- a/tests/unit/test_changelog.py
+++ b/tests/unit/test_changelog.py
@@ -78,6 +78,30 @@ def test_compute_changelog_token(extract_releases):
     assert "1.0.0: A new hope" in node_to_string(nodes[0])
 
 
+def test_compute_changelog_exclude_prereleases(mocker, release):
+    release.is_prerelease = True
+    mocker.patch(
+        "sphinx_github_changelog.github_releases.extract_releases",
+        return_value=[release],
+    )
+    options = config_module.ChangelogDirectiveOptions(
+        github="https://github.com/a/b/releases",
+    )
+    config = config_module.ChangelogConfig(token="token", include_prereleases=False)
+    nodes = changelog.compute_changelog(options=options, config=config)
+    assert nodes == []
+
+
+def test_compute_changelog_include_prereleases(extract_releases, release):
+    release.is_prerelease = True
+    options = config_module.ChangelogDirectiveOptions(
+        github="https://github.com/a/b/releases",
+    )
+    config = config_module.ChangelogConfig(token="token", include_prereleases=True)
+    nodes = changelog.compute_changelog(options=options, config=config)
+    assert "1.0.0: A new hope" in node_to_string(nodes[0])
+
+
 def test_no_token_no_url():
     assert node_to_string(changelog.no_token(changelog_url=None)) == canonicalize(
         """


### PR DESCRIPTION
Add `sphinx_github_changelog_include_prereleases` conf.py option (default: True) to control whether pre-releases appear in the changelog. Can also be set via the
SPHINX_GITHUB_CHANGELOG_INCLUDE_PRERELEASES environment variable.

Closes #121

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
