### PR TITLE
fix: sort releases by publication date instead of creation date

### DIFF
--- a/sphinx_github_changelog/github_releases.py
+++ b/sphinx_github_changelog/github_releases.py
@@ -54,8 +54,13 @@ def extract_releases(
     result = github_call(url=url, payload=payload, token=token)
     try:
         releases = result["data"]["repository"]["releases"]["nodes"]
+        # Sort by publication date descending (API only supports CREATED_AT ordering)
         # If you don't have the right to see draft releases, they're "None"
-        return [Release.from_graphql(r) for r in releases if r]
+        return sorted(
+            (Release.from_graphql(r) for r in releases if r),
+            key=lambda r: r.published_at,
+            reverse=True,
+        )
     except (KeyError, TypeError):
         raise exceptions.GitHubAPIError(
             f"GitHub API error unexpected format:\n{result!r}"


### PR DESCRIPTION
The GitHub GraphQL API only supports ordering by CREATED_AT, but what matters is the publication date. Sort releases client-side by published_at descending so that e.g. a final release appears above a beta that was created earlier but published later.

Closes #125

### Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

<!-- We hope your contributing experience was great so far. If you would like to
provide some feedback, please feel free to do so! -->
